### PR TITLE
Move the IRequestExecutor to APIContext

### DIFF
--- a/src/main/java/com/facebook/ads/sdk/APIContext.java
+++ b/src/main/java/com/facebook/ads/sdk/APIContext.java
@@ -23,24 +23,20 @@
 package com.facebook.ads.sdk;
 
 import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
 
 public class APIContext {
   public static final String DEFAULT_API_BASE = APIConfig.DEFAULT_API_BASE;
   public static final String DEFAULT_API_VERSION = APIConfig.DEFAULT_API_VERSION;
   public static final String DEFAULT_VIDEO_API_BASE = APIConfig.DEFAULT_VIDEO_API_BASE;
-  private String endpointBase;
-  private String videoEndpointBase;
-  private String accessToken;
-  private String appSecret;
-  private String version;
+  private static final IRequestExecutor DEFAULT_REQUEST_EXECUTOR = new DefaultRequestExecutor();
+  private final String endpointBase;
+  private final String videoEndpointBase;
+  private final String accessToken;
+  private final String appSecret;
+  private final String version;
+  private IRequestExecutor requestExecutor = DEFAULT_REQUEST_EXECUTOR;
   protected boolean isDebug = false;
   protected PrintStream logger = System.out;
 
@@ -104,6 +100,14 @@ public class APIContext {
   public APIContext setLogger(PrintStream logger) {
     this.logger = logger;
     return this;
+  }
+
+  public void setRequestExecutor(IRequestExecutor requestExecutor) {
+    this.requestExecutor = requestExecutor;
+  }
+
+  public IRequestExecutor getRequestExecutor() {
+    return requestExecutor;
   }
 
   public void log(String s) {

--- a/src/main/java/com/facebook/ads/sdk/APIRequest.java
+++ b/src/main/java/com/facebook/ads/sdk/APIRequest.java
@@ -22,32 +22,20 @@
  */
 package com.facebook.ads.sdk;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.net.URL;
 import java.net.URLEncoder;
-import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedReader;
 import java.lang.reflect.Modifier;
 import java.lang.StringBuilder;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
-import java.util.Random;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class APIRequest<T extends APINode> {
-
-  public static final String USER_AGENT = APIConfig.USER_AGENT;
-
-  private static IRequestExecutor executor = new DefaultRequestExecutor();
 
   protected APIContext context;
   protected boolean useVideoEndpoint = false;
@@ -59,14 +47,6 @@ public class APIRequest<T extends APINode> {
   protected Map<String, Object> params = new HashMap<String, Object>();
   protected List<String> returnFields;
   private APIResponse lastResponse = null;
-
-  public static void changeRequestExecutor(IRequestExecutor newExecutor) {
-    executor = newExecutor;
-  }
-
-  public static IRequestExecutor getExecutor() {
-    return executor;
-  }
 
   public APIRequest(APIContext context, String nodeId, String endpoint, String method) {
     this(context, nodeId, endpoint, method, null, null);
@@ -156,7 +136,7 @@ public class APIRequest<T extends APINode> {
     String response = null;
     try {
       context.log("========Start of API Call========");
-      response = executor.execute(method, getApiUrl(), getAllParams(extraParams), context);
+      response = context.getRequestExecutor().execute(method, getApiUrl(), getAllParams(extraParams), context);
       context.log("Response:");
       context.log(response);
       context.log("========End of API Call========");
@@ -197,33 +177,6 @@ public class APIRequest<T extends APINode> {
     }
     if (returnFields != null) allParams.put("fields", joinStringList(returnFields));
     return allParams;
-  }
-
-  private static String readResponse(HttpsURLConnection con) throws APIException, IOException {
-    try {
-      int responseCode = con.getResponseCode();
-
-      BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-      String inputLine;
-      StringBuilder response = new StringBuilder();
-
-      while ((inputLine = in.readLine()) != null) {
-        response.append(inputLine);
-      }
-      in.close();
-      return response.toString();
-    } catch(Exception e) {
-
-      BufferedReader in = new BufferedReader(new InputStreamReader(con.getErrorStream()));
-      String inputLine;
-      StringBuilder response = new StringBuilder();
-
-      while ((inputLine = in.readLine()) != null) {
-        response.append(inputLine);
-      }
-      in.close();
-      throw new APIException.FailedRequestException(response.toString(), e);
-    }
   }
 
   private String getApiUrl() {
@@ -308,167 +261,5 @@ public class APIRequest<T extends APINode> {
 
   public static interface ResponseParser<T extends APINode> {
     public APINodeList<T> parseResponse(String response, APIContext context, APIRequest<T> request)  throws APIException.MalformedResponseException;
-  }
-
-  public static interface IRequestExecutor {
-    public String execute(String method, String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
-    public String sendGet(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
-    public String sendPost(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
-    public String sendDelete(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
-  }
-
-  public static class DefaultRequestExecutor implements IRequestExecutor {
-
-    public static Map<String, String> fileToContentTypeMap = new HashMap<String, String>();
-    static {
-      fileToContentTypeMap.put(".atom", "application/atom+xml");
-      fileToContentTypeMap.put(".rss", "application/rss+xml");
-      fileToContentTypeMap.put(".xml", "application/xml");
-      fileToContentTypeMap.put(".csv", "text/csv");
-      fileToContentTypeMap.put(".txt", "text/plain");
-    }
-
-    public String execute(String method, String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
-      if ("GET".equals(method)) return sendGet(apiUrl, allParams, context);
-      else if ("POST".equals(method)) return sendPost(apiUrl, allParams, context);
-      else if ("DELETE".equals(method)) return sendDelete(apiUrl, allParams, context);
-      else throw new IllegalArgumentException("Unsupported http method. Currently only GET, POST, and DELETE are supported");
-    }
-
-    public String sendGet(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
-      StringBuilder urlString = new StringBuilder(apiUrl);
-      boolean firstEntry = true;
-      for (Map.Entry entry : allParams.entrySet()) {
-        urlString.append((firstEntry ? "?" : "&") + URLEncoder.encode(entry.getKey().toString(), "UTF-8") + "=" + URLEncoder.encode(convertToString(entry.getValue()), "UTF-8"));
-        firstEntry = false;
-      }
-      URL url = new URL(urlString.toString());
-      context.log("Request:");
-      context.log("GET: " + url.toString());
-      HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
-
-      con.setRequestMethod("GET");
-      con.setRequestProperty("User-Agent", USER_AGENT);
-      con.setRequestProperty("Content-Type","application/x-www-form-urlencoded");
-
-      return readResponse(con);
-    }
-
-    public String sendPost(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
-      String boundary = "--------------------------" + new Random().nextLong();
-      URL url = new URL(apiUrl);
-      context.log("Post: " + url.toString());
-      HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
-
-      con.setRequestMethod("POST");
-      con.setRequestProperty("User-Agent", USER_AGENT);
-      con.setRequestProperty("Content-Type","multipart/form-data; boundary=" + boundary);
-      con.setDoOutput(true);
-
-      int contentLength = getContentLength(allParams, boundary, context);
-
-      con.setRequestProperty("Content-Length", "" + contentLength);
-
-      DataOutputStream wr = new DataOutputStream(con.getOutputStream());
-      for (Map.Entry entry : allParams.entrySet()) {
-        writeStringInUTF8Bytes(wr, "--" + boundary + "\r\n");
-        if (entry.getValue() instanceof File) {
-          File file = (File) entry.getValue();
-          String contentType = getContentTypeForFile(file);
-          writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + file.getName() + "\"\r\n");
-          if (contentType != null) {
-            writeStringInUTF8Bytes(wr, "Content-Type: " + contentType + "\r\n");
-          }
-          writeStringInUTF8Bytes(wr, "\r\n");
-          FileInputStream fileInputStream = new FileInputStream(file);
-          byte[] buffer = new byte[1024];
-          int count = 0;
-          while ((count = fileInputStream.read(buffer)) >= 0) {
-            wr.write(buffer, 0, count);
-          }
-          writeStringInUTF8Bytes(wr, "\r\n");
-          fileInputStream.close();
-        } else if (entry.getValue() instanceof byte[]) {
-          byte[] bytes = (byte[]) entry.getValue();
-          writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + "chunkfile" + "\"\r\n\r\n");
-          wr.write(bytes, 0, bytes.length);
-          writeStringInUTF8Bytes(wr, "\r\n");
-        } else {
-          writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"\r\n\r\n");
-          writeStringInUTF8Bytes(wr, convertToString(entry.getValue()));
-          writeStringInUTF8Bytes(wr, "\r\n");
-        }
-      }
-      writeStringInUTF8Bytes(wr, "--" + boundary + "--\r\n");
-
-      wr.flush();
-      wr.close();
-
-      return readResponse(con);
-    }
-
-    public String sendDelete(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
-      StringBuilder urlString = new StringBuilder(apiUrl);
-      boolean firstEntry = true;
-      for (Map.Entry entry : allParams.entrySet()) {
-        urlString.append((firstEntry ? "?" : "&") + URLEncoder.encode(entry.getKey().toString(), "UTF-8") + "=" + URLEncoder.encode(convertToString(entry.getValue()), "UTF-8"));
-        firstEntry = false;
-      }
-      URL url = new URL(urlString.toString());
-      context.log("Delete: " + url.toString());
-      HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
-
-      con.setRequestMethod("DELETE");
-      con.setRequestProperty("User-Agent", USER_AGENT);
-
-      return readResponse(con);
-    }
-
-    private static String getContentTypeForFile(File file) {
-      for (Map.Entry entry : fileToContentTypeMap.entrySet()) {
-        if (file.getName().endsWith((String)entry.getKey())) {
-          return (String) entry.getValue();
-        }
-      }
-      return null;
-    }
-
-    private static int getContentLength(Map<String, Object> allParams, String boundary, APIContext context) throws IOException {
-      int contentLength = 0;
-      for (Map.Entry entry : allParams.entrySet()) {
-        contentLength += ("--" + boundary + "\r\n").length();
-        if (entry.getValue() instanceof File) {
-          File file = (File) entry.getValue();
-          String contentType = getContentTypeForFile(file);
-          contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + file.getName() + "\"\r\n");
-          if (contentType != null) {
-            contentLength += getLengthAndLog(context, "Content-Type: " + contentType + "\r\n");
-          }
-          contentLength += getLengthAndLog(context, "\r\n");
-          contentLength += file.length();
-          contentLength += getLengthAndLog(context, "\r\n");
-        } else if (entry.getValue() instanceof byte[]) {
-          byte[] bytes = (byte[]) entry.getValue();
-          contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + "chunkfile" + "\"\r\n");
-          contentLength += bytes.length;
-          contentLength += getLengthAndLog(context, "\r\n");
-        } else {
-          contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"\r\n\r\n");
-          contentLength += getLengthAndLog(context, convertToString(entry.getValue()));
-          contentLength += getLengthAndLog(context, "\r\n");
-        }
-      }
-      contentLength += getLengthAndLog(context, "--" + boundary + "--\r\n");
-      return contentLength;
-    }
-
-    private static int getLengthAndLog(APIContext context, String input) throws IOException {
-      context.log(input);
-      return input.getBytes("UTF-8").length;
-    }
-
-    private static void writeStringInUTF8Bytes(DataOutputStream wr, String input) throws IOException {
-      wr.write(input.getBytes("UTF-8"));
-    }
   }
 }

--- a/src/main/java/com/facebook/ads/sdk/BatchRequest.java
+++ b/src/main/java/com/facebook/ads/sdk/BatchRequest.java
@@ -22,35 +22,22 @@
  */
 package com.facebook.ads.sdk;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
-import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedReader;
-import java.lang.StringBuilder;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.Random;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
 
 public class BatchRequest {
-  List<Pair> requests = new ArrayList<Pair>();
-  APIContext context = null;
+  private final List<Pair> requests = new ArrayList<Pair>();
+  private final APIContext context;
 
   public BatchRequest(APIContext context) {
     this.context = context;
@@ -139,7 +126,7 @@ public class BatchRequest {
     }
     params.put("batch", batch.toString());
     params.putAll(files);
-    return APIRequest.getExecutor().sendPost(context.getEndpointBase() + "/", params, context);
+    return context.getRequestExecutor().sendPost(context.getEndpointBase() + "/", params, context);
   }
 
   public static class BatchModeRequestInfo {

--- a/src/main/java/com/facebook/ads/sdk/DefaultRequestExecutor.java
+++ b/src/main/java/com/facebook/ads/sdk/DefaultRequestExecutor.java
@@ -1,0 +1,213 @@
+package com.facebook.ads.sdk;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.google.gson.Gson;
+
+public class DefaultRequestExecutor implements IRequestExecutor {
+
+    private static final Map<String, String> fileToContentTypeMap = new HashMap<String, String>();
+    static {
+        fileToContentTypeMap.put(".atom", "application/atom+xml");
+        fileToContentTypeMap.put(".rss", "application/rss+xml");
+        fileToContentTypeMap.put(".xml", "application/xml");
+        fileToContentTypeMap.put(".csv", "text/csv");
+        fileToContentTypeMap.put(".txt", "text/plain");
+    }
+
+    public String execute(String method, String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
+        if ("GET".equals(method)) return sendGet(apiUrl, allParams, context);
+        else if ("POST".equals(method)) return sendPost(apiUrl, allParams, context);
+        else if ("DELETE".equals(method)) return sendDelete(apiUrl, allParams, context);
+        else throw new IllegalArgumentException("Unsupported http method. Currently only GET, POST, and DELETE are supported");
+    }
+
+    public String sendGet(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
+        StringBuilder urlString = new StringBuilder(apiUrl);
+        boolean firstEntry = true;
+        for (Map.Entry entry : allParams.entrySet()) {
+            urlString.append((firstEntry ? "?" : "&") + URLEncoder.encode(entry.getKey().toString(), "UTF-8") + "=" + URLEncoder.encode(convertToString(entry.getValue()), "UTF-8"));
+            firstEntry = false;
+        }
+        URL url = new URL(urlString.toString());
+        context.log("Request:");
+        context.log("GET: " + url.toString());
+        HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
+
+        con.setRequestMethod("GET");
+        con.setRequestProperty("User-Agent", APIConfig.USER_AGENT);
+        con.setRequestProperty("Content-Type","application/x-www-form-urlencoded");
+
+        return readResponse(con);
+    }
+
+    public String sendPost(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
+        String boundary = "--------------------------" + new Random().nextLong();
+        URL url = new URL(apiUrl);
+        context.log("Post: " + url.toString());
+        HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
+
+        con.setRequestMethod("POST");
+        con.setRequestProperty("User-Agent", APIConfig.USER_AGENT);
+        con.setRequestProperty("Content-Type","multipart/form-data; boundary=" + boundary);
+        con.setDoOutput(true);
+
+        int contentLength = getContentLength(allParams, boundary, context);
+
+        con.setRequestProperty("Content-Length", "" + contentLength);
+
+        DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+        for (Map.Entry entry : allParams.entrySet()) {
+            writeStringInUTF8Bytes(wr, "--" + boundary + "\r\n");
+            if (entry.getValue() instanceof File) {
+                File file = (File) entry.getValue();
+                String contentType = getContentTypeForFile(file);
+                writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + file.getName() + "\"\r\n");
+                if (contentType != null) {
+                    writeStringInUTF8Bytes(wr, "Content-Type: " + contentType + "\r\n");
+                }
+                writeStringInUTF8Bytes(wr, "\r\n");
+                FileInputStream fileInputStream = new FileInputStream(file);
+                byte[] buffer = new byte[1024];
+                int count = 0;
+                while ((count = fileInputStream.read(buffer)) >= 0) {
+                    wr.write(buffer, 0, count);
+                }
+                writeStringInUTF8Bytes(wr, "\r\n");
+                fileInputStream.close();
+            } else if (entry.getValue() instanceof byte[]) {
+                byte[] bytes = (byte[]) entry.getValue();
+                writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + "chunkfile" + "\"\r\n\r\n");
+                wr.write(bytes, 0, bytes.length);
+                writeStringInUTF8Bytes(wr, "\r\n");
+            } else {
+                writeStringInUTF8Bytes(wr, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"\r\n\r\n");
+                writeStringInUTF8Bytes(wr, convertToString(entry.getValue()));
+                writeStringInUTF8Bytes(wr, "\r\n");
+            }
+        }
+        writeStringInUTF8Bytes(wr, "--" + boundary + "--\r\n");
+
+        wr.flush();
+        wr.close();
+
+        return readResponse(con);
+    }
+
+    public String sendDelete(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException {
+        StringBuilder urlString = new StringBuilder(apiUrl);
+        boolean firstEntry = true;
+        for (Map.Entry entry : allParams.entrySet()) {
+            urlString.append((firstEntry ? "?" : "&") + URLEncoder.encode(entry.getKey().toString(), "UTF-8") + "=" + URLEncoder.encode(convertToString(entry.getValue()), "UTF-8"));
+            firstEntry = false;
+        }
+        URL url = new URL(urlString.toString());
+        context.log("Delete: " + url.toString());
+        HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
+
+        con.setRequestMethod("DELETE");
+        con.setRequestProperty("User-Agent", APIConfig.USER_AGENT);
+
+        return readResponse(con);
+    }
+
+    private static String getContentTypeForFile(File file) {
+        for (Map.Entry entry : fileToContentTypeMap.entrySet()) {
+            if (file.getName().endsWith((String)entry.getKey())) {
+                return (String) entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static int getContentLength(Map<String, Object> allParams, String boundary, APIContext context) throws IOException {
+        int contentLength = 0;
+        for (Map.Entry entry : allParams.entrySet()) {
+            contentLength += ("--" + boundary + "\r\n").length();
+            if (entry.getValue() instanceof File) {
+                File file = (File) entry.getValue();
+                String contentType = getContentTypeForFile(file);
+                contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + file.getName() + "\"\r\n");
+                if (contentType != null) {
+                    contentLength += getLengthAndLog(context, "Content-Type: " + contentType + "\r\n");
+                }
+                contentLength += getLengthAndLog(context, "\r\n");
+                contentLength += file.length();
+                contentLength += getLengthAndLog(context, "\r\n");
+            } else if (entry.getValue() instanceof byte[]) {
+                byte[] bytes = (byte[]) entry.getValue();
+                contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"; filename=\"" + "chunkfile" + "\"\r\n");
+                contentLength += bytes.length;
+                contentLength += getLengthAndLog(context, "\r\n");
+            } else {
+                contentLength += getLengthAndLog(context, "Content-Disposition: form-data; name=\"" + entry.getKey() + "\"\r\n\r\n");
+                contentLength += getLengthAndLog(context, convertToString(entry.getValue()));
+                contentLength += getLengthAndLog(context, "\r\n");
+            }
+        }
+        contentLength += getLengthAndLog(context, "--" + boundary + "--\r\n");
+        return contentLength;
+    }
+
+    private static String convertToString(Object input) {
+        if (input == null) {
+            return "null";
+        } else if (input instanceof Map) {
+            Gson gson = new Gson();
+            return gson.toJson((Map)input);
+        } else if (input instanceof List) {
+            Gson gson = new Gson();
+            return gson.toJson((List)input);
+        } else {
+            return input.toString();
+        }
+    }
+
+    private static String readResponse(HttpsURLConnection con) throws APIException, IOException {
+        try {
+            int responseCode = con.getResponseCode();
+
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            StringBuilder response = new StringBuilder();
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+            return response.toString();
+        } catch(Exception e) {
+
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+            String inputLine;
+            StringBuilder response = new StringBuilder();
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+            throw new APIException.FailedRequestException(response.toString(), e);
+        }
+    }
+
+    private static int getLengthAndLog(APIContext context, String input) throws IOException {
+        context.log(input);
+        return input.getBytes("UTF-8").length;
+    }
+
+    private static void writeStringInUTF8Bytes(DataOutputStream wr, String input) throws IOException {
+        wr.write(input.getBytes("UTF-8"));
+    }
+}

--- a/src/main/java/com/facebook/ads/sdk/IRequestExecutor.java
+++ b/src/main/java/com/facebook/ads/sdk/IRequestExecutor.java
@@ -1,0 +1,11 @@
+package com.facebook.ads.sdk;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface IRequestExecutor {
+    String execute(String method, String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
+    String sendGet(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
+    String sendPost(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
+    String sendDelete(String apiUrl, Map<String, Object> allParams, APIContext context) throws APIException, IOException;
+}


### PR DESCRIPTION
Resolves #27. The request executor is always fetched through the APIContext instance, instead of through a static field on APIRequest. This makes things like dependency injection easier, and allows for use cases where concurrent requests have different or isolated request executors.

Notable changes:
- Split out IRequestExecutor and DefaultRequestExecutor into top level classes in com.facebook.ads.sdk.
- Add a getter/setter for IRequestExecutor on APIContext.
- By default, initialize APIContext with a DefaultRequestExecutor instance.

Note: I did some manual testing, but it would be nice to have unit tests.
