### PR TITLE
Fill getHeader() in APIException class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Unreleased
-
+  - Added function `getHeader()` in APIException class which provides header information
 ## v5.0.1
 
 ### Added
@@ -34,4 +34,3 @@ All notable changes to this project will be documented in this file.
 ## v3.3.0
 ### Changed
 - Graph API call upgrade to [v3.3](https://developers.facebook.com/docs/graph-api/changelog/version3.3)
-

--- a/src/main/java/com/facebook/ads/sdk/APIException.java
+++ b/src/main/java/com/facebook/ads/sdk/APIException.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.List;
 
 public class APIException extends Exception implements APIResponse {
+  private String header;
 
   public APIException () {
     super();
@@ -43,6 +44,11 @@ public class APIException extends Exception implements APIResponse {
 
   public APIException (String message, Throwable e) {
     super(message, e);
+  }
+
+  public APIException (String header, String message, Throwable e) {
+    super(message, e);
+    this.header = header;
   }
 
   @Override
@@ -68,7 +74,7 @@ public class APIException extends Exception implements APIResponse {
 
   @Override
   public String getHeader() {
-    return null;
+    return this.header;
   }
 
   public static class MalformedResponseException extends APIException {
@@ -104,6 +110,10 @@ public class APIException extends Exception implements APIResponse {
 
     public FailedRequestException (String message, Throwable e) {
       super(message, e);
+    }
+
+    public FailedRequestException (String header, String message, Throwable e) {
+      super(header, message, e);
     }
   }
 }

--- a/src/main/java/com/facebook/ads/sdk/APIRequest.java
+++ b/src/main/java/com/facebook/ads/sdk/APIRequest.java
@@ -303,7 +303,9 @@ public class APIRequest<T extends APINode> {
         response.append(inputLine);
       }
       in.close();
-      throw new APIException.FailedRequestException(response.toString(), e);
+      throw new APIException.FailedRequestException(
+        convertToString(con.getHeaderFields()), response.toString(), e
+      );
     }
   }
 


### PR DESCRIPTION
Summary: Filled out function *getHeader()* in APIException class in order to provide header information

Reviewed By: jingping2015

Differential Revision: D18544054

