### PR TITLE
re #309 Fixed APINodeList requesting extra empty page at results end.

### DIFF
--- a/src/main/java/com/facebook/ads/sdk/APINodeList.java
+++ b/src/main/java/com/facebook/ads/sdk/APINodeList.java
@@ -25,10 +25,7 @@ package com.facebook.ads.sdk;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.net.URL;
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -86,12 +83,7 @@ public class APINodeList<T extends APINode> extends ArrayList<T> implements APIR
         }
         return (APINodeList<T>) request.execute();
       }
-      if (after == null) return null;
-      this.request.setOverrideUrl(null);
-      Map<String, Object> extraParams = new HashMap<String, Object>();
-      if (limit > 0) extraParams.put("limit", limit);
-      extraParams.put("after", after);
-      return (APINodeList<T>) request.execute(extraParams);
+      return null;
     }
 
     public void setCursors(String before, String after) {

--- a/src/test/kotlin/com/facebook/ads/sdk/ApiNodeListTest.kt
+++ b/src/test/kotlin/com/facebook/ads/sdk/ApiNodeListTest.kt
@@ -1,0 +1,44 @@
+package com.facebook.ads.sdk
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ApiNodeListTest {
+
+    @Test
+    fun testNextPageWhenNextPageAvailable() {
+        val request = mockk<APIRequest<Campaign>>()
+        val nextPage = mockk<APINodeList<Campaign>>()
+        every { request.setOverrideUrl("https://graph.facebook.api/NEXT") } just Runs
+        every { request.execute() } returns(nextPage)
+        val list = APINodeList<Campaign>(request, "raw value", "header")
+        list.setPaging("https://graph.facebook.api/PREVIOUS", "https://graph.facebook.api/NEXT")
+        list.setCursors("BEFORE_CURSOR", "AFTER_CURSOR")
+
+        val result = list.nextPage()
+
+        assertEquals(nextPage, result)
+        verify {
+            request.setOverrideUrl("https://graph.facebook.api/NEXT")
+        }
+    }
+
+    @Test
+    fun testNextPageWhenAlreadyOnLastPage() {
+        val request = mockk<APIRequest<Campaign>>()
+        val list = APINodeList<Campaign>(request, "raw value", "header")
+        list.setPaging("https://graph.facebook.api/PREVIOUS", null)
+        list.setCursors("BEFORE_CURSOR", "AFTER_CURSOR")
+
+        val result = list.nextPage()
+
+        assertNull(result)
+    }
+
+}


### PR DESCRIPTION
This fixes #309 - APINodeList.nextPage falling back to its original iteration mechanism when `next` link is not present in response, which results in making an extra request that returns no data.