### PR TITLE
Fix bug in requestFieldInternal

### DIFF
--- a/src/main/java/com/facebook/ads/sdk/APIRequest.java
+++ b/src/main/java/com/facebook/ads/sdk/APIRequest.java
@@ -260,10 +260,13 @@ public class APIRequest<T extends APINode> {
     this.overrideUrl = url;
   }
 
-  protected void requestFieldInternal(String field, boolean value) {
+  protected void requestFieldInternal(String field, boolean addField) {
     if (returnFields == null) returnFields = new ArrayList<String>();
-    if (value == true && !returnFields.contains(field)) returnFields.add(field);
-    else returnFields.remove(field);
+    if (addField) {
+      if(!returnFields.contains(field)) returnFields.add(field);
+    } else {
+      returnFields.remove(field);
+    }
   }
 
   private Map<String, Object> getAllParams(Map<String, Object> extraParams) {


### PR DESCRIPTION
there is a bug in the if clause where it would remove a field if it should be added and is already present.

for example if you call `requestAllFields().requestPromotedObjectField(true)` it would actually remove promotedObject instead of keeping it (requestAllFields added it first)