### PR TITLE
Fix flaky tests in `SignalTest.EventRequestTest` and `ServerSideTest#CustomDataParametersTest`

### DIFF
--- a/src/test/java/com/facebook/ads/ServerSideTest.java
+++ b/src/test/java/com/facebook/ads/ServerSideTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class ServerSideTest {
@@ -85,10 +86,13 @@ public class ServerSideTest {
     String serializedPayload = eventRequest.getSerializedPayload();
 
     // ASSERT
-    String cpString = (new Gson()).toJson(customProperties);
     String serializedContents = (new Gson()).toJson(contents);
     String serializedContentIds = (new Gson()).toJson(contentIds);
-    Assert.assertTrue(serializedPayload.contains(cpString.substring(1, cpString.length() - 1)));
+
+    Map<String, String> mp = customProperties; 
+    mp.forEach((key, value) -> Assert.assertTrue(serializedPayload.contains(
+            "\"" + key + "\":" +  "\"" + value + "\"" 
+    ))); 
     Assert.assertTrue(serializedPayload.contains(serializedContents));
     Assert.assertTrue(serializedPayload.contains(serializedContentIds));
     Assert.assertTrue(serializedPayload.contains(currency.toLowerCase()));

--- a/src/test/java/com/facebook/ads/SignalTest.java
+++ b/src/test/java/com/facebook/ads/SignalTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SignalTest {
         @Test
@@ -100,8 +101,9 @@ public class SignalTest {
                 Assert.assertTrue(bdapiDataJSON.contains("\"event_name\":\"Purchase\""));
 
                 String capiDataJSON = (new Gson()).toJson(capiEventRequest.getData());
-                String customPropertiesJSON = (new Gson()).toJson(customProperties);
-                Assert.assertTrue(capiDataJSON
-                                .contains(customPropertiesJSON.substring(1, customPropertiesJSON.length() - 1)));
+                Map<String, String> mp = customProperties; 
+                mp.forEach((key, value) -> Assert.assertTrue(capiDataJSON.contains(
+                        "\"" + key + "\":" +  "\"" + value + "\"" 
+                ))); 
         }
 }


### PR DESCRIPTION
The flakiness comes from the fact that a hashmap data structure is being serialized into a Json object, but the elements in the original hashmap is not deterministic. Thus, we you compare two serialized Json string with each other, although they might contain the same elements, the order can be different during different test runs. 

For checking whether the serialized string does contain all key value pairs, instead it can be done through checking each `{key, value}` pair directly and assert that each individual exists in the serialized string. Since the keys are unique in the hash map, it should be guaranteed that this way it is correctly checking the two compared objects have the same key value pairs.

One thing to note is that `Gson.toJson` can also have indeterministic ordering when the object being json serialized is a `list` type. Thus currently, `Assert.assertTrue(serializedPayload.contains(serializedContents))` and other assertions involving serialized string type objects might be flaky as well. Further examination is needed to address this potential problem. 