### PR TITLE
Fix adding 3 parameter into addCallback call

### DIFF
--- a/src/main/java/com/facebook/ads/sdk/APIRequest.java
+++ b/src/main/java/com/facebook/ads/sdk/APIRequest.java
@@ -46,6 +46,7 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -227,7 +228,7 @@ public class APIRequest<T extends APINode> {
           }
           public void onFailure(Throwable t) {
           }
-        }
+        },  MoreExecutors.directExecutor()
       );
     } catch(IOException e) {
       throw new APIException.FailedRequestException(e);


### PR DESCRIPTION
Added parameter executor to Futures.addCallback call:

[MoreExecutors.directExecutor()](https://guava.dev/releases/22.0/api/docs/com/google/common/util/concurrent/MoreExecutors.html#directExecutor--)